### PR TITLE
Add jsx-no-bind rule

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,5 @@ node_modules
 # Only apps should have lockfiles
 yarn.lock
 package-lock.json
+
+.idea

--- a/index.js
+++ b/index.js
@@ -12,6 +12,7 @@ module.exports = {
     'react/jsx-uses-vars': 1,
     'react/jsx-uses-react': 1,
     'react/jsx-no-undef': 'error',
+    'react/jsx-no-bind': 'error',
   },
   plugins: [
     'react',


### PR DESCRIPTION
Запрещаем использовать стрелочные функции в пропсах, т.к. является антипаттерном и ухудшает производительность:

https://mobx.js.org/best/react-performance.html#bind-functions-early
https://reactjs.org/docs/handling-events.html

The problem with this syntax is that a different callback is created each time the LoggingButton renders. In most cases, this is fine. However, if this callback is passed as a prop to lower components, those components might do an extra re-rendering. We generally recommend binding in the constructor or using the class fields syntax, to avoid this sort of performance problem.
