### PR TITLE
Revert "Pin dependencies (#22)"

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "eslint-plugin-react": "^7.11.0"
   },
   "devDependencies": {
-    "@appbooster/eslint-config-base": "1.4.0",
-    "eslint": "5.16.0"
+    "@appbooster/eslint-config-base": "^1.3.0",
+    "eslint": "^5.0.0"
   }
 }


### PR DESCRIPTION
В #22 @appbooster-bot через renovate запинил зависимости — для библиотечных проектов такая стратегия не подходит, тут нужна гибкая поддержка версий, а не одной конкретной (что намного лучше работает в обычных проектах, не библиотеках)