### PR TITLE
Migrate eslint to v6: Fix overrides option

### DIFF
--- a/index.js
+++ b/index.js
@@ -27,10 +27,10 @@ module.exports = {
     'react',
     'jest',
   ],
-  overrides: {
+  overrides: [{
     files: ['**/*.test.js'],
     env: {
       'jest/globals': true,
     },
-  },
+  }],
 }

--- a/package.json
+++ b/package.json
@@ -25,6 +25,6 @@
   },
   "devDependencies": {
     "@appbooster/eslint-config-base": "^1.3.0",
-    "eslint": "^5.0.0"
+    "eslint": "^6.5.1"
   }
 }


### PR DESCRIPTION
#### :tophat: Что? Зачем?
Для миграции на 6 версию еслинта нужно обновить секцию overrides